### PR TITLE
Update word_cloud_setting.dart

### DIFF
--- a/word_cloud/lib/word_cloud_setting.dart
+++ b/word_cloud/lib/word_cloud_setting.dart
@@ -213,7 +213,7 @@ class WordCloudSetting {
       return false;
     }
     for (int i = x.toInt(); i < x.toInt() + w; i++) {
-      if (map[i][y + h - 1] == 1) {
+      if (map[i][y + h.toInt() - 1] == 1) {
         return false;
       }
       if (map[i][y + 1] == 1) {


### PR DESCRIPTION
There's a test failure when running a widget test for WordCloud. It's because the addition of an int and a double. The fix is to covert the double to int.