### PR TITLE
Allow optional explicit word coloring.

### DIFF
--- a/word_cloud/README.md
+++ b/word_cloud/README.md
@@ -16,17 +16,17 @@ To use the word cloud widget, you must set the desired data into the `WordCloudD
 ```dart
 WordCloudData mydata = WordCloudData(data: data_list);
 ```
-Parameter `data` needs list of `Map` that have keys `word` and `value`.  
+Parameter `data` needs list of `Map` that have keys `word`, `value` and optionally `color`.  
 For example,
 ```dart
 List<Map> data_list= [
-  {'word': 'Apple','value': 100},
+  {'word': 'Apple','value': 100, 'color': Colors.amber},
   {'word': 'Samsung','value': 60},
 ];
 ```
 Another way to set the data is using instance method `addData`.  
 ```dart
-mydata.addData(String word, Double value);
+mydata.addData(String word, Double value, {Color? color});
 ```
 
 ## WordCloudView
@@ -67,7 +67,7 @@ WordCloudView(
   colorlist: [Colors.black, Colors.redAccent, Colors.indigoAccent],
 )
 ```
-With the `colorlist` parameter, you can change word's font color. You should input list of `Color` . Word cloud will select font color ***Randomly***.  
+With the `colorlist` parameter, you can change word's font color. You should input list of `Color` . Word cloud will select font color ***Randomly*** for any word that has not been assigned a color explicitly in the `WordCloudData` structure.  
 
 ![캡처](https://drive.google.com/uc?export=view&id=1Br7XiPwr4KRNglr61NmzSW396AGHZ4JR)
 

--- a/word_cloud/example/lib/main.dart
+++ b/word_cloud/example/lib/main.dart
@@ -36,8 +36,8 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   //example data list
   List<Map> word_list = [
-    {'word': 'Apple', 'value': 100},
-    {'word': 'Samsung', 'value': 60},
+    {'word': 'Apple', 'value': 100, 'color': Colors.amber},
+    {'word': 'Samsung', 'value': 60, 'color': Colors.green},
     {'word': 'Intel', 'value': 55},
     {'word': 'Tesla', 'value': 50},
     {'word': 'AMD', 'value': 40},
@@ -115,10 +115,8 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-
     WordCloudData wcdata = WordCloudData(data: word_list);
     WordCloudTap wordtaps = WordCloudTap();
-
 
     //WordCloudTap Setting
     for (int i = 0; i < word_list.length; i++) {
@@ -132,8 +130,6 @@ class _MyHomePageState extends State<MyHomePage> {
       wordtaps.addWordtap(word_list[i]['word'], tap);
     }
 
-
-
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -141,39 +137,49 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       body: Center(
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text('Clicked Word : ${wordstring}', style: TextStyle(fontSize: 20),),
-            Text('Clicked Count : ${count}', style: TextStyle(fontSize: 20)),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                WordCloudTapView(
-                  data: wcdata,
-                  wordtap: wordtaps,
-                  mapcolor: Color.fromARGB(255, 174, 183, 235),
-                  mapwidth: 500,
-                  mapheight: 500,
-                  fontWeight: FontWeight.bold,
-                  shape: WordCloudCircle(radius: 250),
-                  colorlist: [Colors.black, Colors.redAccent, Colors.indigoAccent],
-                ),
-                SizedBox(
-                  height: 15,
-                  width:30,
-                ),
-                WordCloudView(
-                  data: wcdata,
-                  mapcolor: Color.fromARGB(255, 174, 183, 235),
-                  mapwidth: 500,
-                  mapheight: 500,
-                  fontWeight: FontWeight.bold,
-                  colorlist: [Colors.black, Colors.redAccent, Colors.indigoAccent],
-                ),
-              ],
-            ),
-          ]
-        ),
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                'Clicked Word : ${wordstring}',
+                style: TextStyle(fontSize: 20),
+              ),
+              Text('Clicked Count : ${count}', style: TextStyle(fontSize: 20)),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  WordCloudTapView(
+                    data: wcdata,
+                    wordtap: wordtaps,
+                    mapcolor: Color.fromARGB(255, 174, 183, 235),
+                    mapwidth: 500,
+                    mapheight: 500,
+                    fontWeight: FontWeight.bold,
+                    shape: WordCloudCircle(radius: 250),
+                    colorlist: [
+                      Colors.black,
+                      Colors.redAccent,
+                      Colors.indigoAccent
+                    ],
+                  ),
+                  SizedBox(
+                    height: 15,
+                    width: 30,
+                  ),
+                  WordCloudView(
+                    data: wcdata,
+                    mapcolor: Color.fromARGB(255, 174, 183, 235),
+                    mapwidth: 500,
+                    mapheight: 500,
+                    fontWeight: FontWeight.bold,
+                    colorlist: [
+                      Colors.black,
+                      Colors.redAccent,
+                      Colors.indigoAccent
+                    ],
+                  ),
+                ],
+              ),
+            ]),
       ),
     );
   }

--- a/word_cloud/lib/word_cloud_data.dart
+++ b/word_cloud/lib/word_cloud_data.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 class WordCloudData {
   List<Map> data = [];
 
@@ -16,8 +18,12 @@ class WordCloudData {
         .toList();
   }
 
-  void addData(String word, double value) {
-    data.add({'word': word, 'value': value});
+  void addData(String word, double value, {Color? color}) {
+    data.add({
+      'word': word,
+      'value': value,
+      if (color != null) 'color': color,
+    });
     data = (data..sort((a, b) => a['value'].compareTo(b['value'])))
         .reversed
         .toList();

--- a/word_cloud/lib/word_cloud_setting.dart
+++ b/word_cloud/lib/word_cloud_setting.dart
@@ -129,7 +129,8 @@ class WordCloudSetting {
       final textSpan = TextSpan(
         text: data[i]['word'],
         style: TextStyle(
-          color: colorList?[Random().nextInt(colorList!.length)],
+          color: data[i]['color'] ??
+              colorList?[Random().nextInt(colorList!.length)],
           fontSize: getTextSize,
           fontWeight: fontWeight,
           fontFamily: fontFamily,


### PR DESCRIPTION
Add a new key in the `WordCloudData` underlying map that allows to optionally set colors for words in the cloud.

If no explicit color is set, a color from the `colorList` is randomly selected as before.